### PR TITLE
FIX: REMOVE_NEO4J: [Search] Relax "required" requirements for "primary"/"secondary" in SetDesignTaggingsObject [CON-1687] 

### DIFF
--- a/docs/SetDesignTaggingsObject.md
+++ b/docs/SetDesignTaggingsObject.md
@@ -6,8 +6,8 @@ Name | Type | Description | Notes
 **design_id** | **int** | design id | 
 **discoverable** | **bool** | true if the design is discoverable | 
 **discoverable_before** | **bool** | true if the design was already discoverable | 
-**primary** | **str** | primary tag name | 
-**secondary** | **list[str]** | secondary tag names | 
+**primary** | **str** | primary tag name | [optional] 
+**secondary** | **list[str]** | secondary tag names | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/swagger_client/models/set_design_taggings_object.py
+++ b/swagger_client/models/set_design_taggings_object.py
@@ -64,8 +64,10 @@ class SetDesignTaggingsObject(object):
         self.design_id = design_id
         self.discoverable = discoverable
         self.discoverable_before = discoverable_before
-        self.primary = primary
-        self.secondary = secondary
+        if primary is not None:
+            self.primary = primary
+        if secondary is not None:
+            self.secondary = secondary
 
     @property
     def design_id(self):
@@ -162,8 +164,6 @@ class SetDesignTaggingsObject(object):
         :param primary: The primary of this SetDesignTaggingsObject.  # noqa: E501
         :type: str
         """
-        if self._configuration.client_side_validation and primary is None:
-            raise ValueError("Invalid value for `primary`, must not be `None`")  # noqa: E501
 
         self._primary = primary
 
@@ -187,8 +187,6 @@ class SetDesignTaggingsObject(object):
         :param secondary: The secondary of this SetDesignTaggingsObject.  # noqa: E501
         :type: list[str]
         """
-        if self._configuration.client_side_validation and secondary is None:
-            raise ValueError("Invalid value for `secondary`, must not be `None`")  # noqa: E501
 
         self._secondary = secondary
 


### PR DESCRIPTION
### Context

Relax the "required" requirements for "primary"/"secondary" in SetDesignTaggingsObject in the new Search API to mimic what the (non-validating) Neo4j design model that the new Search API is meant to replace.

See also [CON-1687](https://teepublic.atlassian.net/browse/CON-1687).

### Proposed Changes

- update files affected by re-running `java --add-opens=java.base/java.util=ALL-UNNAMED -jar ./lib/swagger-codegen-cli-2.4.19.jar generate -i search_swagger_2_0.yaml -l python -o ../teepublic-search-client-python/` from the `teepublic-search` repo;
- note that the package version (1.0.0) is left unchanged at this time, in line with previous commits.

### Automated Tests and QA
- manually tested that search-admin can still successfully query Search;

[CON-1687]: https://teepublic.atlassian.net/browse/CON-1687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ