### PR TITLE
FIX: Resolve deprecation warning for editable installs [CON-2647]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
**Proposed Changes**
- Caused by https://github.com/TeePublic/teepublic-airflow/pull/784
- Resolve the following deprecation warning by adding a pyproject.toml file
```
DEPRECATION: Legacy editable install of swagger_client from git+https://github.com/TeePublic/teepublic-search-client-python.git@d23faf1635dc12864044a014cdff4d0c50ab42cb#egg=swagger_client (from -r requirements.txt (line 40)) (setup.py develop) is deprecated. pip 25.0 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457
```

From the docs ([ref](https://github.com/pypa/pip/issues/11457)):
> If you have received a deprecation warning about a legacy editable install, pip is using the legacy setup.py develop method for performing an editable installation of your project. In practice, this usually means one of two things:
> - The pyproject.toml file doesn’t exist at all, thus pip will opt-out of the modern mechanism and use setup.py develop
> - The declared setuptools version (in the [build-system].requires field) is too old and doesn’t support PEP 660, i.e. anything older than setuptools 64.0.0

**QA**
`pip install -e .` completes without deprecation warnings. The output of that line references `pyproject.toml`:
```
Obtaining file:///Users/alyssamcgillvery/projects/teepublic-search-client-python
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: certifi>=2017.4.17 in ./venv/lib/python3.9/site-packages (from swagger-client==1.0.0) (2020.12.5)
Requirement already satisfied: python-dateutil>=2.1 in ./venv/lib/python3.9/site-packages (from swagger-client==1.0.0) (2.8.1)
Requirement already satisfied: six>=1.10 in ./venv/lib/python3.9/site-packages (from swagger-client==1.0.0) (1.15.0)
Requirement already satisfied: urllib3>=1.23 in ./venv/lib/python3.9/site-packages (from swagger-client==1.0.0) (1.26.4)
Building wheels for collected packages: swagger-client
  Building editable for swagger-client (pyproject.toml) ... done
  Created wheel for swagger-client: filename=swagger_client-1.0.0-0.editable-py3-none-any.whl size=2985 sha256=94ec873bfd95519c5983e709e0642801e9dff82c9ae5b1611d1a47820b946563
  Stored in directory: /private/var/folders/mw/c_7xbggs2vddwzkzb9zk10y80000gn/T/pip-ephem-wheel-cache-awg_wscz/wheels/b5/46/b2/8bb328e7352ed492e07c8e468e74ecc20a81328d8097e45aef
Successfully built swagger-client
Installing collected packages: swagger-client
  Attempting uninstall: swagger-client
    Found existing installation: swagger-client 1.0.0
    Uninstalling swagger-client-1.0.0:
      Successfully uninstalled swagger-client-1.0.0
Successfully installed swagger-client-1.0.0
```
